### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ MarkupSafe==0.23
 path.py==8.1.2
 pexpect==4.0.1
 pickleshare==0.5
-psycopg2-binary==2.8.6
+psycopg2==2.8.6
 ptyprocess==0.5
 pylibmc==1.5.1
 PyYAML==3.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ MarkupSafe==0.23
 path.py==8.1.2
 pexpect==4.0.1
 pickleshare==0.5
-psycopg2==2.7.4
+psycopg2-binary==2.8.6
 ptyprocess==0.5
 pylibmc==1.5.1
 PyYAML==3.11
@@ -32,7 +32,7 @@ setproctitle==1.1.9
 simplegeneric==0.8.1
 six==1.10.0
 sqlparse==0.1.18
-traitlets==4.0.0
+traitlets==5.3.0
 Werkzeug==0.11.3
 wheel==0.24.0
 whitenoise==2.0.6


### PR DESCRIPTION
ipython 7.16.3 now depends on traitlets>=4.2 (changed to newest 5.3.0)
changed psycopg2 to standalone binary to fix errors